### PR TITLE
fix: navigation error while item screen navigation

### DIFF
--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,0 +1,12 @@
+import { RootStackParamList } from "../stack";
+
+type screens = {
+    LIST_SCREEN:keyof RootStackParamList,
+    ITEM_SCREEN:keyof RootStackParamList
+}
+
+export const SCREEN_NAME:screens = {
+    LIST_SCREEN : "ListScreen",
+    ITEM_SCREEN : "ItemScreen",
+}
+

--- a/src/screens/list/components/item.tsx
+++ b/src/screens/list/components/item.tsx
@@ -8,6 +8,8 @@ import {RootStackParamList} from '../../../stack';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {IListItem} from '../index';
 import {Avatar} from '../../../components/avatar';
+import {SCREEN_NAME} from '../../../constants/routes';
+
 
 //
 //
@@ -21,7 +23,7 @@ export const ListItem: React.FC<{item: IListItem}> = ({item}) => {
     >();
 
   return (
-    <ListItemContainer onPress={() => nav.navigate('Itemscreen', item)}>
+    <ListItemContainer onPress={() => nav.navigate(SCREEN_NAME.ITEM_SCREEN, item)}>
       <Avatar
         style={styles.image}
         source={{uri: getImage(thumbnailSize, item.id)}}

--- a/src/stack.tsx
+++ b/src/stack.tsx
@@ -3,6 +3,7 @@ import {createNativeStackNavigator} from '@react-navigation/native-stack';
 
 import ListScreen, {IListItem} from './screens/list';
 import {Item} from './item';
+import {SCREEN_NAME} from './constants/routes';
 
 import {ThemeFont} from './components/typography';
 
@@ -19,7 +20,7 @@ const RootStack = createNativeStackNavigator<RootStackParamList>();
 const Stack = () => {
   return (
     <RootStack.Navigator
-      initialRouteName="ListScreens"
+      initialRouteName={SCREEN_NAME.LIST_SCREEN}
       screenOptions={{
         headerShadowVisible: false,
         headerBackTitle: '',
@@ -32,12 +33,12 @@ const Stack = () => {
         },
       }}>
       <RootStack.Screen
-        name="ListScreen"
+        name={SCREEN_NAME.LIST_SCREEN}
         component={ListScreen}
         options={{title: 'Items'}}
       />
       <RootStack.Screen
-        name="ItemScreen"
+        name={SCREEN_NAME.ITEM_SCREEN}
         component={Item}
         options={{title: 'Item'}}
       />


### PR DESCRIPTION
cause :  navigation was not happening cause we were passing "Itemscreen" instead of "ItemScreen".

to avoid such future mistake i have added a constant file containing all screen name in constant and used this constant name instead of hard coded string name,

with aproach we can avoid such spell/case error