### PR TITLE
replace scrollview with flatlist to improve performance

### DIFF
--- a/src/screens/list/index.tsx
+++ b/src/screens/list/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ScrollView} from 'react-native';
+import {FlatList} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 
 import ListData from '../../utils/fake-data';
@@ -17,14 +17,16 @@ export interface IListItem {
   brand: String;
 }
 
+// TODO: ustilize FlatList property onEndReached & onEndReachedThreshold to load items lazyly(eg: load +50 records on each scroll end)
+
 const ListScreen = () => {
   return (
     <SafeAreaView edges={['top', 'bottom']}>
-      <ScrollView contentContainerStyle={{paddingHorizontal: 16}}>
-        {ListData.map(item => (
-          <ListItem key={item.id} item={item} />
-        ))}
-      </ScrollView>
+       <FlatList
+        data={ListData}
+        renderItem={({item}) => <ListItem key={item.id} item={item} />}
+        keyExtractor={item => item.id}
+      />
     </SafeAreaView>
   );
 };


### PR DESCRIPTION
**Problem**: we were loading 1500 listitems using scrollview which was trying to load all data at once and causing performance issue

**Solution**: replace scrollview with flatlist to improve performance

**Reason**: Since Flatlist is does not load all data at once but lazyly unlike scrollview its better alternative in this case as we are loading 1500 recors at once 

**TODO**: later we can improve this on furture level by utilising FlatList property onEndReached & onEndReachedThreshold and loading only few records on each scrollend