### PR TITLE
style: update screen pages to match figma design

### DIFF
--- a/src/components/container.tsx
+++ b/src/components/container.tsx
@@ -5,6 +5,6 @@ import {Platform, TextStyle} from 'react-native';
 //
 
 export const Container = styled.View({
-  paddingHorizontal: 25,
+  paddingHorizontal: 20,
   paddingVertical: 8,
 });

--- a/src/components/details-line.tsx
+++ b/src/components/details-line.tsx
@@ -8,15 +8,16 @@ import {Typography} from './typography';
 
 export const DetailsLine: React.FC<{
   label?: React.ReactNode;
-  children: string;
-}> = ({label, children}) => {
+  children: React.ReactNode;
+  isBold?:boolean
+}> = ({label, children, isBold=false}) => {
   return (
     <DetailsLineContainer>
-      <Typography fontSize={14} style={{marginRight: 16}} weight="medium">
+      <Typography color={"#545454"} fontSize={14} style={{marginRight: 16}} weight="medium">
         {label}
       </Typography>
 
-      <DetailsLineContent>{children}</DetailsLineContent>
+      <DetailsLineContent style={{fontWeight: isBold?"bold":"normal"}}>{children}</DetailsLineContent>
     </DetailsLineContainer>
   );
 };

--- a/src/components/details-title.tsx
+++ b/src/components/details-title.tsx
@@ -10,5 +10,7 @@ export const DetailsTitle = styled(Typography)({
 });
 
 DetailsTitle.defaultProps = {
-  weight: 'medium',
+  weight: 'bold',
+  fontSize:16,
+  color:"black"
 };

--- a/src/components/item-price.tsx
+++ b/src/components/item-price.tsx
@@ -1,0 +1,22 @@
+import { View } from "react-native"
+import { Typography } from "./typography"
+import { styles } from "../styles";
+
+export const ItemPrice: React.FC<{ salePrice: string, price: string, size?: number }> = ({ salePrice, price, size = 18 }) => {
+    return (
+        <View>
+            {salePrice ? (
+                <Typography>
+                    <Typography style={[styles.discounted,styles.itemPrice]} fontSize={size}>SAR {price}</Typography>
+                    <Typography fontSize={size} color="red">
+                        {'  '}
+                        SAR {price}
+                    </Typography>
+                </Typography>
+            ) : (
+                <Typography color="black" fontSize={size}>SAR {price}</Typography>
+            )}
+        </View>
+    )
+}
+

--- a/src/constants/images.ts
+++ b/src/constants/images.ts
@@ -1,0 +1,2 @@
+export const THUMBNAIL_SIZE = 600
+export const ITEM_IMAGE_SIZE = 0.9

--- a/src/item.tsx
+++ b/src/item.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState,useEffect} from 'react';
 import {Dimensions, ScrollView, Text, View} from 'react-native';
 import {RouteProp, useNavigation, useRoute} from '@react-navigation/native';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
@@ -12,16 +12,14 @@ import {Typography} from './components/typography';
 import {DetailsLine} from './components/details-line';
 import {DetailsTitle} from './components/details-title';
 import {Cart} from './components/cart';
-
-//
-//
+import { ITEM_IMAGE_SIZE } from "./constants/images";
+import { styles } from "./styles/index";
+import { ItemPrice } from "./components/item-price";
 
 const SPEC_1 = faker.color.human();
 const SPEC_2 = faker.vehicle.vin();
 const SPEC_3 = faker.commerce.product();
 const SPEC_4 = faker.datatype.float({min: 0.1, max: 10, precision: 0.1});
-
-//
 
 export const Item = () => {
   const nav =
@@ -36,51 +34,42 @@ export const Item = () => {
     return <Typography>Loading ...</Typography>;
   }
 
-  nav.setOptions({
-    title: params.name,
-  });
+  useEffect(()=>{
+    nav.setOptions({
+      title: params.name,
+    });
+  },[])
 
-  //
-  //
 
   return (
     <React.Fragment>
-      <ScrollView>
-        <Container>
+      <ScrollView style={{backgroundColor:"#f9f9f9"}}>
+        <Container >
           <ItemImage
             source={{uri: getImage(900, params.id)}}
-            size={Dimensions.get('screen').width * 0.9}
+            size={Dimensions.get('screen').width * ITEM_IMAGE_SIZE}
           />
-        </Container>
-
-        <Container>
-          <Typography fontSize={18} weight="semiBold">
+        
+          <Typography style={[styles.itemHeader,styles.fontLarg]} weight="bold">
             {params.name}
           </Typography>
 
-          {params.salePrice ? (
-            <Typography fontSize={18} color="red">
-              <ItemDiscountedPrice>SAR {params.price}</ItemDiscountedPrice>
-              {'  '}
-              SAR {params.price}
-            </Typography>
-          ) : (
-            <Typography fontSize={18}>SAR {params.price}</Typography>
-          )}
+          <ItemPrice salePrice={params.salePrice} price={params.price}></ItemPrice>
+          
         </Container>
 
         <Container>
           <Typography>{params.description}</Typography>
         </Container>
 
-        <Container>
+        <Container >
           <DetailsTitle>Details</DetailsTitle>
           <DetailsLine label="Brand">{params.brand}</DetailsLine>
           <DetailsLine label="Color">{SPEC_1}</DetailsLine>
-          <DetailsLine label="SKU">{SPEC_2}</DetailsLine>
+          <DetailsLine isBold={true} label="SKU">{SPEC_2}</DetailsLine>
 
-          <Typography weight="medium" />
-          <Typography weight="medium">Specifications</Typography>
+          <DetailsTitle>Specifications</DetailsTitle>
+
           <DetailsLine label="Type">{SPEC_3}</DetailsLine>
           <DetailsLine label="Weight">{SPEC_4} kg</DetailsLine>
         </Container>
@@ -91,9 +80,6 @@ export const Item = () => {
   );
 };
 
-//
-//
-
 const ItemImage = styled.Image<{size: number}>(props => ({
   width: props.size,
   height: props.size,
@@ -102,11 +88,7 @@ const ItemImage = styled.Image<{size: number}>(props => ({
   borderRadius: 9,
 }));
 
-const ItemDiscountedPrice = styled(Typography)({
-  textDecorationLine: 'line-through',
-});
-
-ItemDiscountedPrice.defaultProps = {
-  fontSize: 18,
-  color: 'black',
+Typography.defaultProps = {
+  color:"black"
 };
+

--- a/src/screens/list/components/item.tsx
+++ b/src/screens/list/components/item.tsx
@@ -1,86 +1,44 @@
 import React from 'react';
-import {StyleSheet, View} from 'react-native';
-import {useNavigation} from '@react-navigation/native';
-import styled from '@emotion/native';
-import {getImage} from '../../../utils/image';
-import {Typography} from '../../../components/typography';
-import {RootStackParamList} from '../../../stack';
-import {NativeStackNavigationProp} from '@react-navigation/native-stack';
-import {IListItem} from '../index';
-import {Avatar} from '../../../components/avatar';
-import {SCREEN_NAME} from '../../../constants/routes';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { getImage } from '../../../utils/image';
+import { Typography } from '../../../components/typography';
+import { RootStackParamList } from '../../../stack';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { IListItem } from '../index';
+import { Avatar } from '../../../components/avatar';
+import { SCREEN_NAME } from '../../../constants/routes';
+import { THUMBNAIL_SIZE } from '../../../constants/images';
+import { styles } from '../../../styles/index';
+import { ItemPrice } from "../../../components/item-price";
 
 
-//
-//
-
-const thumbnailSize = 600;
-
-export const ListItem: React.FC<{item: IListItem}> = ({item}) => {
+export const ListItem: React.FC<{ item: IListItem }> = ({ item }) => {
   const nav =
     useNavigation<
       NativeStackNavigationProp<RootStackParamList, 'ListScreen'>
     >();
 
   return (
-    <ListItemContainer onPress={() => nav.navigate(SCREEN_NAME.ITEM_SCREEN, item)}>
+    <TouchableOpacity style={styles.ListItemContainer} onPress={() => nav.navigate(SCREEN_NAME.ITEM_SCREEN, item)}>
       <Avatar
         style={styles.image}
-        source={{uri: getImage(thumbnailSize, item.id)}}
+        source={{ uri: getImage(THUMBNAIL_SIZE, item.id) }}
       />
 
       <View style={styles.flex}>
-        <Typography weight="medium">{item.name}</Typography>
-        {!item.salePrice ? (
-          <Typography style={item.salePrice ? styles.discounted : undefined}>
-            SAR {item.price}
-          </Typography>
-        ) : null}
+        <Typography style={styles.itemHeader}>{item.name}</Typography>
 
-        {item.salePrice ? (
-          <Typography color="#DA2121">
-            <Typography style={item.salePrice ? styles.discounted : undefined}>
-              SAR {item.price}
-            </Typography>
-            {'  '}SAR {item.salePrice}
-          </Typography>
-        ) : null}
+        <ItemPrice salePrice={item.salePrice} price={item.price} size={16}></ItemPrice>
 
-        <Typography fontSize={14} color="#545454">
+
+        <Typography style={styles.itemBrand}>
           Brand: {item.name}
         </Typography>
       </View>
-    </ListItemContainer>
+    </TouchableOpacity>
   );
 };
 
-//
-//
 
-const ListItemContainer = styled.TouchableOpacity({
-  paddingTop: 10,
-  paddingBottom: 10,
-  paddingHorizontal: 25,
-  borderBottomColor: 'rgba(0,0, 0, 0.05)',
-  borderBottomWidth: 1,
-  flexDirection: 'row',
-});
 
-//
-//
-
-const styles = StyleSheet.create({
-  flex: {
-    flex: 1,
-  },
-  image: {
-    marginTop: 8,
-    marginRight: 16,
-  },
-  discounted: {
-    textDecorationLine: 'line-through',
-  },
-  sale: {
-    color: '#DA2121',
-  },
-});

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,0 +1,43 @@
+import { StyleSheet } from "react-native";
+
+export const styles = StyleSheet.create({
+    flex: {
+      flex: 1,
+    },
+    image: {
+      marginTop: 8,
+      marginRight: 16,
+    },
+    discounted: {
+      textDecorationLine: 'line-through',
+    },
+    salePrice:{
+      color: '#DA2121',
+    },
+    itemHeader:{
+      fontWeight:"bold",
+      color:"black"
+    },
+    itemPrice:{
+      color:"black",
+    },
+    itemBrand:{
+      color:"#545454",
+      fontSize:14
+    },
+  
+    fontLarg:{
+      fontSize:18
+    },     
+    
+    ListItemContainer:{
+    paddingTop: 10,
+    paddingBottom: 10,
+    paddingHorizontal: 25,
+    borderBottomColor: 'rgba(0,0, 0, 0.05)',
+    borderBottomWidth: 1,
+    flexDirection: 'row',
+    backgroundColor:"#f9f9f9"
+  
+    }
+  });


### PR DESCRIPTION
**Problem**: the current app screens pages were not matching with figma prototype provided

**Solution**:
- update screen pages styles to match figma design
- reuse code by creating ItemPrice componenet and reused it on both screen
- create common style file and use same style file on both screen 

**TODO**: 

- to use all style property eg color and font size from a central constant file so it can be easy to manage when the app has too many pages
- using flex for alignment instead of margin/padding(using flex we can ensure same design alignment over veriety of different devices)
- create wraper componenet eg for typography which will gives more controlls over style with code reusibility
